### PR TITLE
Remove 'appendBaseElement' and add 'getBaseUrl" methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ var vdomDiff = require('virtual-dom/diff');
 var vdomCreate = require('virtual-dom/create-element');
 var serialize = require('vdom-serialized-patch/serialize');
 var vdomPatch = require('vdom-serialized-patch/patch');
-var findBaseNode = require('./vdom-ext').findBaseNode;
-var appendBaseElement = require('./vdom-ext').appendBaseElement;
+var getBaseUrl = require('./vdom-ext').getBaseUrl;
 var vNodeCleanupUrls = require('./vdom-ext').vNodeCleanupUrls;
 var patchCleanupUrls = require('./vdom-ext').patchCleanupUrls;
 
@@ -102,8 +101,7 @@ module.exports = {
   diff: diff,
   patch: patch,
   createElement: vdomCreate,
-  findBaseNode: findBaseNode,
-  appendBaseElement: appendBaseElement,
+  getBaseUrl: getBaseUrl,
   vNodeCleanupUrls: vNodeCleanupUrls,
   patchCleanupUrls: patchCleanupUrls
 };

--- a/test/vdom-ext-test.js
+++ b/test/vdom-ext-test.js
@@ -4,7 +4,6 @@ var h = require('virtual-dom/h');
 // Module under test (MUT)
 var MUT = require('../vdom-ext');
 var findBaseNode = MUT.findBaseNode;
-var appendBaseElement = MUT.appendBaseElement;
 var vNodeCleanupUrls = MUT.vNodeCleanupUrls;
 var patchCleanupUrls = MUT.patchCleanupUrls;
 
@@ -52,54 +51,6 @@ describe('vdom-ext', function() {
 
       assert.equal(relativeBaseElement, findBaseNode(treeWithRelativeBaseElement));
       assert.isNotOk(findBaseNode(treeWithoutBaseElement));
-    });
-  });
-
-  describe('#appendBaseElement()', function() {
-    it('appends base element', function() {
-      var tree = createTree();
-      var actual = appendBaseElement(createTree(), 'http://example.com');
-
-      assertEqualVNode(createBaseElement('http://example.com'), findBaseNode(actual));
-    });
-
-    it('updates relative base element from attribute', function() {
-      var tree = createTree(createBaseElement('/relative'));
-      var actual = appendBaseElement(tree, 'http://example.com');
-
-      assertEqualVNode(createBaseElement('http://example.com/relative'), findBaseNode(actual));
-    });
-
-    it('updates relative base element from property', function() {
-      var tree = createTree(createBaseElement('/relative', true));
-      var actual = appendBaseElement(tree, 'http://example.com');
-
-      assertEqualVNode(createBaseElement('http://example.com/relative'), findBaseNode(actual));
-    });
-
-    it('takes care of dashes when concatenating relative base element', function() {
-      var tree = createTree(createBaseElement('/relative'));
-      var actual = appendBaseElement(tree, 'http://example.com/');
-
-      assertEqualVNode(createBaseElement('http://example.com/relative'), findBaseNode(actual));
-    });
-
-    it("doesn't update absolute base element", function() {
-      var absoluteBaseElement = createBaseElement('http://crazyegg.com/');
-      var tree = createTree(absoluteBaseElement);
-
-      var actual = appendBaseElement(tree, 'http://example.com');
-
-      assert.equal('http://crazyegg.com/', findBaseNode(actual).properties.attributes.href);
-    });
-
-    it("doesn't update protocol relative base element", function() {
-      var protocolRelativeBaseElement = createBaseElement('//crazyegg.com/');
-      var tree = createTree(protocolRelativeBaseElement);
-
-      var actual = appendBaseElement(tree, 'http://example.com');
-
-      assert.equal('//crazyegg.com/', findBaseNode(actual).properties.attributes.href);
     });
   });
 

--- a/vdom-ext.js
+++ b/vdom-ext.js
@@ -114,48 +114,6 @@ var EXPECTED_PROTOCOL = /^(https?|data):\/\//i;
 var TRANSPARENT_GIF_DATA = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP';
 
 /**
- * Insert a <base> node to a vdom tree
- *
- * @param {VNode} - root node
- * @param {String} - base's href URL to append
- * @return {VNode}
- */
-function appendBaseElement(root, href) {
-  var base = findBaseNode(root),
-      head;
-
-  if (!base) {
-    // append <base> element
-    head = findNodeOfType(root, 'HEAD');
-
-    if (head) {
-      // FIXME: Use vdom/vnode function or hyperscript to generate node
-      head.children.unshift(h('base', { attributes: { href: href } }));
-    } else {
-      // FIXME: Need to add base tag at the top of the document
-    }
-  } else {
-    // modify <base> element
-    base.properties.attributes = base.properties.attributes || {};
-
-    var actualHref = base.properties.href || base.properties.attributes.href || '';
-
-    if (!(PROTOCOL_RELATIVE_URL.test(actualHref.toLowerCase()) || ABSOLUTE_URL.test(actualHref.toLowerCase()))) {
-
-      if (/\/$/.test(href) && /^\//.test(actualHref)) {
-        // fix slashes
-        actualHref = actualHref.slice(1);
-      }
-
-      base.properties.attributes.href = href + actualHref;
-      delete base.properties.href;
-    }
-  }
-
-  return root;
-}
-
-/**
  * Change src from all node with a src with an unexpected protocol
  *
  * @param {VNode}
@@ -196,7 +154,6 @@ function patchCleanupUrls(patches, proxyUrl, baseUrl) {
 
 module.exports = {
   findBaseNode: findBaseNode,
-  appendBaseElement: appendBaseElement,
   vNodeCleanupUrls: vNodeCleanupUrls,
   patchCleanupUrls: patchCleanupUrls
 };


### PR DESCRIPTION
`getBaseUrl` is needed for rare cases when BASE tag was originally present on recorded webpage. This case was considered in `appendBaseElement` method, so I decided to not skip it as well.

This method considers BASE element and returns proper URL that is used as a base URL for all relative links under proxy.

See tests and jsDocs to understand how it works.