### PR TITLE
[CE-70] Recordings: scrolling does not work in firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var vdomCreate = require('virtual-dom/create-element');
 var serialize = require('vdom-serialized-patch/serialize');
 var vdomPatch = require('vdom-serialized-patch/patch');
 var getBaseUrl = require('./vdom-ext').getBaseUrl;
+var findNodeOfType = require('./vdom-ext').findNodeOfType;
 var vNodeCleanupUrls = require('./vdom-ext').vNodeCleanupUrls;
 var patchCleanupUrls = require('./vdom-ext').patchCleanupUrls;
 
@@ -100,8 +101,10 @@ module.exports = {
   parse: parse,
   diff: diff,
   patch: patch,
+  serialize: serialize,
   createElement: vdomCreate,
   getBaseUrl: getBaseUrl,
+  findNodeOfType: findNodeOfType,
   vNodeCleanupUrls: vNodeCleanupUrls,
   patchCleanupUrls: patchCleanupUrls
 };

--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ module.exports = {
   parse: parse,
   diff: diff,
   patch: patch,
-  serialize: serialize,
   createElement: vdomCreate,
   getBaseUrl: getBaseUrl,
   findNodeOfType: findNodeOfType,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var serialize = require('vdom-serialized-patch/serialize');
 var vdomPatch = require('vdom-serialized-patch/patch');
 var getBaseUrl = require('./vdom-ext').getBaseUrl;
 var findNodeOfType = require('./vdom-ext').findNodeOfType;
+var getNodeIndex = require('./vdom-ext').getNodeIndex;
 var vNodeCleanupUrls = require('./vdom-ext').vNodeCleanupUrls;
 var patchCleanupUrls = require('./vdom-ext').patchCleanupUrls;
 
@@ -104,6 +105,7 @@ module.exports = {
   createElement: vdomCreate,
   getBaseUrl: getBaseUrl,
   findNodeOfType: findNodeOfType,
+  getNodeIndex: getNodeIndex,
   vNodeCleanupUrls: vNodeCleanupUrls,
   patchCleanupUrls: patchCleanupUrls
 };

--- a/test/vdom-ext-test.js
+++ b/test/vdom-ext-test.js
@@ -6,6 +6,7 @@ var MUT = require('../vdom-ext');
 var getBaseUrl = MUT.getBaseUrl;
 var vNodeCleanupUrls = MUT.vNodeCleanupUrls;
 var patchCleanupUrls = MUT.patchCleanupUrls;
+var getNodeIndex = MUT.getNodeIndex;
 
 function createBaseElement(href, asProperty) {
   var props = { };
@@ -66,6 +67,38 @@ describe('vdom-ext', function() {
     proxyUrl + "http:/test.com/img.jpg",
     proxyUrl + "http:/test.com/img.png"
   ];
+
+  describe('#getNodeIndex()', function() {
+    var tree = createTree();
+
+    it('returns 0 for HTML element', function() {
+      assert.equal(getNodeIndex(tree, tree), 0);
+    });
+
+    it('returns 1 for HEAD element', function() {
+      assert.equal(getNodeIndex(tree, tree.children[0]), 1);
+    });
+
+    it('returns 2 for first child of head', function() {
+      assert.equal(getNodeIndex(tree, tree.children[0].children[0]), 2);
+    });
+
+    it('returns 5 for last child of head', function() {
+      assert.equal(getNodeIndex(tree, tree.children[0].children[2]), 5);
+    });
+
+    it('returns 6 for BODY element', function() {
+      assert.equal(getNodeIndex(tree, tree.children[1]), 6);
+    });
+
+    it('returns 7 for H1 element', function() {
+      assert.equal(getNodeIndex(tree, tree.children[1].children[0]), 7);
+    });
+
+    it('returns -1 for non-existent element', function() {
+      assert.equal(getNodeIndex(tree, {}), -1);
+    });
+  });
 
   describe('#getBaseUrl()', function() {
     it('returns host unchanged if there is no BASE element', function() {

--- a/vdom-ext.js
+++ b/vdom-ext.js
@@ -178,9 +178,48 @@ function patchCleanupUrls(patches, proxyUrl, baseUrl) {
   return patches;
 }
 
+/**
+ * Get unique index of node in virtual tree (used in diffs&patches).
+ * Example of nodes indexing:
+ *
+ *                      Root (0)
+ *  Head (1)             TextNode (13)          Body (14)
+ *  HeadNodes (2-12)                        Div (15)            AnotherDiv (21)
+ *                                          DivNodes (16-20)    ...
+ *
+ * Thus, to get index of a node we have to traverse the tree using depth-first search,
+ * incrementing index (initialized with 0) with each visited node.
+ *
+ * @param {VNode} tree - root node of the virtual tree
+ * @param {VNode} node
+ * @returns {number}
+ */
+function getNodeIndex(tree, node) {
+    var index = 0;
+    var match = false;
+
+    tree = tree instanceof Array ? tree : [tree];
+
+    (function recurse(tree) {
+      for (var i = 0; i < tree.length && !match; i++, index++) {
+        if (tree[i] == node) {
+          match = true;
+          return;
+        }
+
+        if (tree[i].children) {
+          recurse(tree[i].children);
+        }
+      }
+    })(tree);
+
+    return match ? index : -1;
+}
+
 module.exports = {
   getBaseUrl: getBaseUrl,
   vNodeCleanupUrls: vNodeCleanupUrls,
   patchCleanupUrls: patchCleanupUrls,
-  findNodeOfType: findNodeOfType
+  findNodeOfType: findNodeOfType,
+  getNodeIndex: getNodeIndex
 };

--- a/vdom-ext.js
+++ b/vdom-ext.js
@@ -181,5 +181,6 @@ function patchCleanupUrls(patches, proxyUrl, baseUrl) {
 module.exports = {
   getBaseUrl: getBaseUrl,
   vNodeCleanupUrls: vNodeCleanupUrls,
-  patchCleanupUrls: patchCleanupUrls
+  patchCleanupUrls: patchCleanupUrls,
+  findNodeOfType: findNodeOfType
 };


### PR DESCRIPTION
https://xohellobar.atlassian.net/browse/CE-70

In order to apply scroll to recording manually (outside of diffs), we have to extract scroll data from frames diffs (patches). In order to extract properties from patches we have to first get indices of body and html elements, and then find those indices in patch. That's why we need 'getNodeIndex' method.